### PR TITLE
Fixed broken import from python-can package

### DIFF
--- a/bin/j1939_logger.py
+++ b/bin/j1939_logger.py
@@ -95,7 +95,7 @@ def parse_arguments():
     '''))
 
     parser.add_argument('-i', '--interface', dest="interface",
-                        #choices=can.interface.VALID_INTERFACES,
+                        #choices=can.interfaces.VALID_INTERFACES,
                         help=textwrap.dedent('''\
     Specify the backend CAN interface to use.
 
@@ -103,7 +103,7 @@ def parse_arguments():
         {}
 
     Alternatively the CAN_INTERFACE environment variable can be set.
-    '''.format(can.interface.VALID_INTERFACES)))
+    '''.format(can.interfaces.VALID_INTERFACES)))
 
     return parser.parse_args()
 

--- a/bin/j1939_logger.py
+++ b/bin/j1939_logger.py
@@ -21,7 +21,6 @@ if 1:
     logger.addHandler(ch)
 
 
-
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description=textwrap.dedent("""\
@@ -134,7 +133,6 @@ if __name__ == "__main__":
     if args.filter is not None:
         filters = json.load(args.filter)
         print("Loaded filters from file: ", filters)
-
 
     print("args.channel  : ", args.channel)
     print("args.interface: ", args.interface)

--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -23,7 +23,7 @@ import copy
 
 # By this stage the can.rc should have been set up
 from can import Message
-from can.interfaces.interface import Bus as RawCanBus
+from can.interface import Bus as RawCanBus
 from can.notifier import Notifier as canNotifier
 from can.bus import BusABC
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ python-j1939 requires the setuptools package to be installed.
 import logging
 from setuptools import setup, find_packages
 
-__version__ = "0.1.0-alpha.1"
+__version__ = "0.1.0-alpha.2"
 
 logging.basicConfig(level=logging.WARNING)
 


### PR DESCRIPTION
An update in the python-can package moved a bunch of files around and changed where the Bus class and the VALID_INTERFACES variable resides.