### PR TITLE
Fixed broken import from python-can package (part 2)

### DIFF
--- a/bin/j1939_logger.py
+++ b/bin/j1939_logger.py
@@ -107,7 +107,6 @@ def parse_arguments():
 
 
 if __name__ == "__main__":
-
     args = parse_arguments()
 
     verbosity = args.verbosity
@@ -122,7 +121,6 @@ if __name__ == "__main__":
         for pgn in args.pgn:
             if pgn.startswith('0x'):
                 pgn = int(pgn[2:], base=16)
-
             filters.append({'pgn': int(pgn)})
     if args.source is not None:
         for src in args.source:

--- a/bin/j1939_logger.py
+++ b/bin/j1939_logger.py
@@ -101,7 +101,7 @@ def parse_arguments():
         {}
 
     Alternatively the CAN_INTERFACE environment variable can be set.
-    '''.format(can.interfaces.interface.VALID_INTERFACES)))
+    '''.format(can.interfaces.VALID_INTERFACES)))
 
     return parser.parse_args()
 
@@ -112,8 +112,6 @@ if __name__ == "__main__":
     verbosity = args.verbosity
     logging_level_name = ['critical', 'error', 'warning', 'info', 'debug', 'subdebug'][min(5, verbosity)]
     can.set_logging_level(logging_level_name)
-
-    from can.interfaces.interface import *
 
     filters = []
     if args.pgn is not None:

--- a/bin/j1939_logger.py
+++ b/bin/j1939_logger.py
@@ -136,6 +136,7 @@ if __name__ == "__main__":
     print("filters       : ", filters)
 
     bus = j1939.Bus(channel=args.channel, bustype=args.interface, j1939_filters=filters, timeout=0.1)
+    print("channel info  : ", bus.can_bus.channel_info)
     log_start_time = datetime.datetime.now()
     print('can.j1939 logger started on {}\n'.format(log_start_time))
     logger.info('can.j1939 logger started on {}\n'.format(log_start_time))

--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -22,7 +22,7 @@ import copy
 # By this stage the can.rc should have been set up
 from can import Message
 from can import set_logging_level as can_set_logging_level
-from can.interfaces.interface import Bus as RawCanBus
+from can.interface import Bus as RawCanBus
 from can.notifier import Notifier as canNotifier
 from can.bus import BusABC
 

--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -21,14 +21,10 @@ import copy
 
 # By this stage the can.rc should have been set up
 from can import Message
-
 from can import set_logging_level as can_set_logging_level
 from can.interfaces.interface import Bus as RawCanBus
-
 from can.notifier import Notifier as canNotifier
 from can.bus import BusABC
-
-
 
 # Import our new message type
 from j1939.pdu import PDU
@@ -83,7 +79,6 @@ class Bus(BusABC):
         self._key_generation_fcn = None
         if 'keygen' in kwargs and kwargs['keygen'] is not None:
             self._key_generation_fcn = kwargs['keygen']
-
 
         if broadcast:
             self.node_queue_list = [(None,  self)]  # Start with default logger Queue which will receive everything
@@ -163,29 +158,24 @@ class Bus(BusABC):
                         l_notifier.queue.put(inboundMessage)
 
                     # if node has the destination address, do something with the PDU
-                    #
                     elif node and (arbitration_id.destination_address in node.address_list):
                         rx_pdu = self._process_incoming_message(inboundMessage)
                         if rx_pdu:
                             logger.info("WP02: notification: sent to general queue: %s QQ=%s" % (rx_pdu, self.queue))
                             self.queue.put(rx_pdu)
-
                     elif node and (arbitration_id.destination_address is None):
                         logger.info("notification: sending broadcast to general queue")
                         rx_pdu = self._process_incoming_message(inboundMessage)
                         logger.info("WP01: notification: sent broadcast to general queue: %s QQ=%s" % (rx_pdu, self.queue))
                         self.queue.put(rx_pdu)
-
                     elif node is None:
                         # always send the message to the logging queue
                         logger.info("notification: sending to general queue")
                         rx_pdu = self._process_incoming_message(inboundMessage)
                         logger.info("WP03: notification: sent 'none' to general queue")
                         self.queue.put(rx_pdu)
-
                     else:
                         logger.info("WP04: notification: pdu dropped: %s\n\n" % inboundMessage)
-
             else:
                 logger.info("Received non J1939 message (ignoring)")
 
@@ -365,8 +355,6 @@ class Bus(BusABC):
 
         return None
 
-
-
     def _process_incoming_message(self, msg):
         logger.info("PI01: Processing incoming message: instance=%s\n  msg=  %s" % (self, msg))
         arbitration_id = ArbitrationID()
@@ -443,7 +431,7 @@ class Bus(BusABC):
 
                     # Find a Node object so we can search its list of known node addresses for this node
                     # so we can find if we are responsible for sending the EOM ACK message
-					# TODO: Was self.j1939_notifier.listeners
+                    # TODO: Was self.j1939_notifier.listeners
 
                     send_ack = any(True for (_listener, l_notifier) in self.node_queue_list
                             if isinstance(_listener, Node) and

--- a/j1939/arbitrationid.py
+++ b/j1939/arbitrationid.py
@@ -123,8 +123,6 @@ class ArbitrationID(object):
             self._pgn = other
 
     def __str__(self):
-
-
         logger.debug("arbitrationid.__str__: ids:%d, pri:%s, pgn:%s, dest:%s, src:%s" %
                 (self.pgn.is_destination_specific, self.priority, self.pgn, self.destination_address_value, self.source_address))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ python-j1939 requires the setuptools package to be installed.
 import logging
 from setuptools import setup, find_packages
 
-__version__ = "0.1.0-alpha.2"
+__version__ = "0.1.0-alpha.3"
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -24,7 +24,7 @@ setup(
         "doc": ["*.*"]
     },
 
-    install_requires=["python-can>=1.5"],
+    install_requires=["python-can>=2.0.0a2"],
 
     scripts=["./bin/j1939_logger.py"],
 


### PR DESCRIPTION
An update in the python-can package moved a bunch of files around and changed where the Bus class and the VALID_INTERFACES variable resides.

A merge after my last pull request (#3) undid some of the changes from before, so this pull request is to re-apply them.