### PR TITLE
Update __init__.py

### DIFF
--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -52,6 +52,8 @@ chformatter = logging.Formatter('%(name)25s | %(threadName)10s | %(levelname)5s 
 ch.setFormatter(chformatter)
 #logger.addHandler(ch)
 
+__version__ = "1.0.0"
+
 if 1:
     fileHandler = logging.handlers.RotatingFileHandler(os.path.join(tempfile.gettempdir(), \
                                                        'j1939.log'), \


### PR DESCRIPTION
Taken from the python-can project, seems this should add the possibility to pull up the version number by j1939.__version__
Though not sure if I added it at the right position and also whether the version number is correct. Feel free to correct.
Or maybe version 1.5.x would be better as 1.5.0 was the last working python-can with the j1939 package in it? Anyway, you probably have a better idea. Thanks.