### PR TITLE
enables operation with 11-bit CAN messages

### DIFF
--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -84,9 +84,12 @@ class Bus(BusABC):
 
     :param bool strict:
         indicates whether to operate on strictly J1939 message (True)
-        or also handle 11-bit CAN messages.  If False, then any specfified
-        `can_filters` will be honored; incoming 11-bit messages will be
-        accepted; and outgoing 11-bit messages will be sent.
+        or also handle 11-bit CAN messages (False).  In strict operation,
+        specification of `j1939_filters` will override any specification of
+        `can_filters`; inbound and outbound 11-bit CAN messages will be
+        dropped.  In non-strict operation, `j1939_filters` will add to
+        `can_filters`; inbound and outbound 11-bit CAN messages will be
+        accepted and sent, respectively.
 
     :param list j1939_filters:
         a list of dictionaries that specify filters that messages must

--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -83,7 +83,6 @@ class Bus(BusABC):
     A CAN Bus that implements the J1939 Protocol.
 
     :param bool strict:
-
         indicates whether to operate on strictly J1939 message (True)
         or also handle 11-bit CAN messages.  If False, then any specfified
         `can_filters` will be honored; incoming 11-bit messages will be


### PR DESCRIPTION
fixes #18 

Introduces a new `strict` parameter to `Bus` that specifies whether to operate strictly on J1939 messages or J1939 and 11-bit CAN messages.  `strict=True` by default to maintain the current behavior.

Handling of PDU vs non-PDU messages is broken out into separate methods.

So far, this seems to work fine for me as a simple drop-in replacement for `can.interface.Bus` using existing 11-bit messaging.