### PR TITLE
changes for allowing j1939 to work with Python 3.11

### DIFF
--- a/bin/j1939_mem_query.py
+++ b/bin/j1939_mem_query.py
@@ -15,13 +15,14 @@ if sys.version_info < MIN_PYTHON:
 import j1939.utils
 
 if __name__ == "__main__":
-    import traceback
-    import timeit
-    import time
+    # import traceback
+    # import timeit
+    # import time
+    # import textwrap
+    # import inspect
     import argparse
     import logging
-    import textwrap
-    import inspect
+
 
 
 if __name__ == "__main__":
@@ -60,6 +61,10 @@ if __name__ == "__main__":
     parser.add_argument("-c", "--channel",
                   default="can0",
                   help="Memory object pointer offset to request in decimal or 0xHex")
+    
+    parser.add_argument("-b", "--bustype",
+                  default="socketcan",
+                  help="This depends on the channel for pcan use PCAN_USBBUS1")
 
     parser.add_argument("extension",
                   default=None,
@@ -96,9 +101,10 @@ if __name__ == "__main__":
     ext = int(args.extension, 0)
     speed = int(args.speed, 0)
     channel = args.channel
+    bustype = args.bustype
     logging.info ("get_mem_object_single(src=0x%02x, dest=0x%02x, pointer=0x%02x, extension/space=0x%02x, len=%d" % (source, dest, ptr, ext, length))
 
-    val = j1939.utils.get_mem_object(ptr, ext, length=length, src=source, dest=dest, channel=channel, speed=speed)
+    val = j1939.utils.get_mem_object(ptr, ext, length=length, src=source, dest=dest, channel=channel, bustype=bustype, speed=speed)
     print("{}".format(val))
     out = ''
     if isinstance(val, list):

--- a/bin/j1939_mem_set.py
+++ b/bin/j1939_mem_set.py
@@ -54,7 +54,8 @@ examples:
     parser.add_argument("-t", "--timeout", default="1000", help="ms before the request times out (default=1000 or 1s)")
     parser.add_argument("-s", "--source", default="0", help="source address (0-254) default=0")
     parser.add_argument("-d", "--destination", default="0x17", help="destination address (0-254) default=17")
-    parser.add_argument("-c", "--channel", default="can0", help="Generally can0 on workstations or can1 on bbb/pbb targets")
+    parser.add_argument("-c", "--channel", default="can0", help="Generally can0 or PCAN_USBBUS1 on workstations or can1 on bbb/pbb targets")
+    parser.add_argument("-b", "--bustype", default="socketcan", help="channel bus type i.e. socketcan, pcan")
     parser.add_argument("-r", "--robot", action="store_true", default=False, help="provide parsable result data to aid robot testing")
     parser.add_argument("-v", "--verbose", action="store_true", default=False, help="Generate debugging output")
     parser.add_argument(      "--string", action="store_true", default=False, help="Treat an integer parameter as a string")
@@ -133,7 +134,7 @@ examples:
     # queries a couple objects but setting up the full stack and bus for
     # each takes a long time.
     start = timeit.default_timer()
-    val = j1939.utils.set_mem_object(ptr, ext, value, speed=args.speed, channel=args.channel, length=length, src=src, dest=dest, timeout=timeout)
+    val = j1939.utils.set_mem_object(ptr, ext, value, speed=args.speed, channel=args.channel, bustype=args.bustype, length=length, src=src, dest=dest, timeout=timeout)
     #set_mem_object_single(length=1, src=0, dest=0x17, pointer=0x66, extension=0xea, value=127)
     print("elapsed = %s s" % (timeit.default_timer() - start))
     print("return val = {}".format(int(val!=1)))

--- a/j1939/__init__.py
+++ b/j1939/__init__.py
@@ -175,7 +175,7 @@ class Bus(BusABC):
 
         if isinstance(inboundMessage, Message):
             logger.info('\n\n{}:  Got a Message from CAN: {}'.format(inspect.stack()[0][3],inboundMessage))
-            if inboundMessage.id_type:
+            if inboundMessage.is_extended_id:
                 # Extended ID
                 # Only J1939 messages (i.e. 29-bit IDs) should go further than this point.
                 # Non-J1939 systems can co-exist with J1939 systems, but J1939 doesn't care
@@ -302,7 +302,7 @@ class Bus(BusABC):
 
                 logger.info("MIL8: j1939.send: segment=%d, arb = %s" % (i, arbitration_id))
                 message = Message(arbitration_id=arbitration_id.can_id,
-                                  extended_id=True,
+                                  is_extended_id=True,
                                   dlc=(len(segment) + 1),
                                   data=(bytearray([i + 1]) + segment))
                 messages.append(message)
@@ -346,7 +346,7 @@ class Bus(BusABC):
                pdu.arbitration_id.destination_address != DESTINATION_ADDRESS_GLOBAL:
                 # send request to send
                 logger.debug("MIL8: rts to specific dest: src=%s, dest=%s" % (pdu.source, destination_address))
-                rts_msg = Message(extended_id=True,
+                rts_msg = Message(is_extended_id=True,
                                   arbitration_id=rts_arbitration_id.can_id,
                                   data=[CM_MSG_TYPE_RTS,
                                         pdu_length_msb,
@@ -368,7 +368,7 @@ class Bus(BusABC):
                 rts_arbitration_id.pgn.pdu_specific = DESTINATION_ADDRESS_GLOBAL
                 rts_arbitration_id.destination_address = DESTINATION_ADDRESS_GLOBAL
                 logger.debug("MIL8: rts to Global dest: src=%s, dest=%s" % (pdu.source, destination_address))
-                bam_msg = Message(extended_id=True,
+                bam_msg = Message(is_extended_id=True,
                                   arbitration_id=rts_arbitration_id.can_id | pdu.source,
                                   data=[CM_MSG_TYPE_BAM,
                                         pdu_length_msb,
@@ -399,7 +399,7 @@ class Bus(BusABC):
             msg.display_radix = 'hex'
             logger.debug("j1939.send: calling can_bus_send: j1939-msg: {}, arb-id: {:08x}".format(msg, msg.arbitration_id.can_id))
             can_message = Message(arbitration_id=msg.arbitration_id.can_id,
-                                  extended_id=True,
+                                  is_extended_id=True,
                                   dlc=len(msg.data),
                                   data=msg.data)
 
@@ -561,7 +561,7 @@ class Bus(BusABC):
                                 ())
                         div, mod = divmod(total_length, 256)
                         can_message = Message(arbitration_id=arbitration_id.can_id,
-                                              extended_id=True,
+                                              is_extended_id=True,
                                               dlc=8,
                                               data=[CM_MSG_TYPE_EOM_ACK,
                                                     mod,  # total_length % 256,
@@ -654,7 +654,7 @@ class Bus(BusABC):
                         _data = [0x11, msg.data[4], 0x01, 0xFF, 0xFF]
                         _data.extend(msg.data[5:])
                         logger.debug("send CTS: AID: %s" % _cts_arbitration_id)
-                        cts_msg = Message(extended_id=True, arbitration_id=_cts_arbitration_id.can_id, data=_data,
+                        cts_msg = Message(is_extended_id=True, arbitration_id=_cts_arbitration_id.can_id, data=_data,
                                           dlc=8)
 
                         # send clear to send
@@ -683,7 +683,7 @@ class Bus(BusABC):
                             _data = [0x11, msg.data[4], 0x01, 0xFF, 0xFF]
                             _data.extend(msg.data[5:])
                             logger.debug("send CTS: AID: %s" % _cts_arbitration_id)
-                            cts_msg = Message(extended_id=True, arbitration_id=_cts_arbitration_id.can_id, data=_data,
+                            cts_msg = Message(is_extended_id=True, arbitration_id=_cts_arbitration_id.can_id, data=_data,
                                               dlc=8)
 
                             # send clear to send

--- a/j1939/utils.py
+++ b/j1939/utils.py
@@ -53,18 +53,11 @@ def set_mem_object(pointer, extension, value, channel='can0', bustype='socketcan
     # only watch for the memory object pgn's
     filt = [{'pgn':0xd800, 'source':dest},{'pgn':0xd400, 'source':dest}]
 
-    if sys.platform == 'win32':
-        if bus is None:
-            bus = j1939.Bus(timeout=0.01, keygen=keygetFunction, broadcast=None, name='j1939StartGeneral', ignoreCanSendError=True, j1939_filters=filt)
-            node = j1939.Node(bus, j1939.NodeName(), [src])
-            bus.connect(node)
-            close = True
-    else:
-        if bus is None:
-            bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction, broadcast=False, j1939_filters=filt)
-            node = j1939.Node(bus, j1939.NodeName(), [src])
-            bus.connect(node)
-            close = True
+    if bus is None:
+        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction, broadcast=False, j1939_filters=filt)
+        node = j1939.Node(bus, j1939.NodeName(), [src])
+        bus.connect(node)
+        close = True
 
     pLow = pointer & 0x0000FF
     pMid = (pointer >> 8) & 0x0000FF
@@ -76,7 +69,6 @@ def set_mem_object(pointer, extension, value, channel='can0', bustype='socketcan
     dm14aid = j1939.ArbitrationID(pgn=dm14pgn, source_address=src, destination_address=dest)
     dm14pdu = j1939.PDU(timestamp=0.0, arbitration_id=dm14aid, data=dm14data, info_strings=None)
     dm14pdu.display_radix='hex'
-
 
     bus.send(dm14pdu)
 
@@ -223,9 +215,7 @@ def request_pgn(requested_pgn, channel='can0', speed=250, bustype='socketcan', l
 
     if not isinstance(requested_pgn, int):
         raise ValueError("pgn must be an integer.")
-#    if bus is None:
-#        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01)
-#        close = True
+
     if bus is None:
         bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction, broadcast=False)
         node = j1939.Node(bus, j1939.NodeName(), [src])
@@ -271,6 +261,7 @@ def request_pgn(requested_pgn, channel='can0', speed=250, bustype='socketcan', l
 def send_pgn(requested_pgn, data, channel='can0', speed=250, bustype='socketcan', length=4, src=0, dest=0x17, bus=None, timeout=10):
     countdown = timeout
     result = None
+    close = False
 
     keygetFunction = None
     if speed == 250:
@@ -283,8 +274,7 @@ def send_pgn(requested_pgn, data, channel='can0', speed=250, bustype='socketcan'
     if bus is None:
         bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction)
         close = True
-    else:
-        close = False
+        
     pgn = j1939.PGN()
     if requested_pgn < 0xf000:
         requested_pgn |= dest

--- a/j1939/utils.py
+++ b/j1939/utils.py
@@ -54,7 +54,7 @@ def set_mem_object(pointer, extension, value, channel='can0', bustype='socketcan
     filt = [{'pgn':0xd800, 'source':dest},{'pgn':0xd400, 'source':dest}]
 
     if bus is None:
-        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction, broadcast=False, j1939_filters=filt)
+        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction, speed=speed, bitrate=(int(speed)*1000), broadcast=False, j1939_filters=filt)
         node = j1939.Node(bus, j1939.NodeName(), [src])
         bus.connect(node)
         close = True
@@ -73,10 +73,6 @@ def set_mem_object(pointer, extension, value, channel='can0', bustype='socketcan
     bus.send(dm14pdu)
 
     sendBuffer = []
-    #sendBuffer.append(length)
-    #for i in range(0, length):
-    #    sendBuffer.append(0)
-
     logger.info("---------------## length=%d, value=%s " % (length, value))
     if isinstance(value, int) and length < 8:
         logger.info("-----value")
@@ -145,7 +141,7 @@ def get_mem_object(pointer, extension, channel='can0', bustype='socketcan', leng
     close = False
 
     if bus is None:
-        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, broadcast=False)
+        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, speed=speed, bitrate=(int(speed)*1000), broadcast=False)
         node = j1939.Node(bus, j1939.NodeName(), [src])
         bus.connect(node)
         close = True
@@ -217,7 +213,7 @@ def request_pgn(requested_pgn, channel='can0', speed=250, bustype='socketcan', l
         raise ValueError("pgn must be an integer.")
 
     if bus is None:
-        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction, broadcast=False)
+        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, speed=speed, bitrate=(int(speed)*1000), keygen=keygetFunction, broadcast=False)
         node = j1939.Node(bus, j1939.NodeName(), [src])
         bus.connect(node)
         close = True
@@ -272,7 +268,7 @@ def send_pgn(requested_pgn, data, channel='can0', speed=250, bustype='socketcan'
     if not isinstance(requested_pgn, int):
         raise ValueError("pgn must be an integer.")
     if bus is None:
-        bus = j1939.Bus(channel=channel, bustype=bustype, timeout=0.01, keygen=keygetFunction)
+        bus = j1939.Bus(channel=channel, bustype=bustype, speed=speed, bitrate=(int(speed)*1000), timeout=0.01, keygen=keygetFunction)
         close = True
         
     pgn = j1939.PGN()


### PR DESCRIPTION
Had to change the mesage - id_type to is_extended_id, also had to had bustype to mem_set and mem_query. Removed  sys.plaform == 'win32' now that we have the bustype, this allows us to use the same bus methods.